### PR TITLE
Fix issue with didScanCard event not firing.

### DIFF
--- a/ios/RCTCardIO/RCTCardIOView.m
+++ b/ios/RCTCardIO/RCTCardIOView.m
@@ -22,8 +22,6 @@ RCT_ENUM_CONVERTER(CardIODetectionMode, (@{
     CardIOView *cardIOView;
 }
 
-@synthesize bridge, methodQueue;
-
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_VIEW_PROPERTY(hidden, BOOL);


### PR DESCRIPTION
I wish I knew better why it fixed the issue, but after I removed this line the event fired as expected.
