### PR TITLE
Add postinstall script to unzip libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "url": "git@github.com:kayla-tech/react-native-card-io.git"
   },
   "main": "index.js",
+  "scripts": {
+    "postinstall": "unzip ios/libs/card.io-iOS-SDK/CardIO/libCardIO.a.zip -d ios/libs/card.io-iOS-SDK/CardIO/"
+  },
   "keywords": [
     "react-component",
     "react-native",

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,6 @@ A fully featured implementation of [card.io](https://www.card.io/) for iOS and A
 ## Installation iOS
 
 1. Run `npm install react-native-card-io --save` in your project directory.
-1. Inside `node_modules`, unzip `react-native-card-io/ios/libs/card.io-iOS-SDK/CardIO/libCardIO.a.zip`.
 1. Open your project in XCode (make sure to open `.xcworkspace` NOT `.xcproject`), right click on `Libraries` and click `Add Files to "Your Project Name"`.
 1. Within `node_modules`, find `react-native-card-io/ios` and add `RCTCardIO.xcodeproj` to your project.
 1. Add `libRCTCardIO.a` to `Build Phases -> Link Binary With Libraries`.


### PR DESCRIPTION
https://github.com/kayla-tech/react-native-card-io/issues/11

Putting them in postinstall since we don't want to publish 200 MB libs
